### PR TITLE
Remove Travis build status from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Build Status](https://api.travis-ci.com/apache/fineract-cn-cassandra.svg?branch=develop)](https://travis-ci.com/apache/fineract-cn-cassandra)
-
 # Apache Fineract CN Cassandra
 
 This project provides helps for using Cassandra in Fineract CN services.


### PR DESCRIPTION
Due to the removal of the Travis build scripts from the project. The build status in the README.md is now misleading and needs to be removed.